### PR TITLE
タッチデバイス向けキーボード UI の user-select を none に

### DIFF
--- a/style.css
+++ b/style.css
@@ -249,6 +249,7 @@ hr {
     0
     calc(var(--keyboard-key-margin) / 2 + env(safe-area-inset-bottom, 0));
   background: gainsboro;
+  user-select: none;
 }
 
 .keyboard-preview {


### PR DESCRIPTION
Fix #18